### PR TITLE
Change to Python3.12 to compile with GraphRAG-1.2.0

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.12-slim
 
 WORKDIR /app
 

--- a/Dockerfile.manage
+++ b/Dockerfile.manage
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.12-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
GraphRAG 1.2.0 requires Python < 3.13