### PR TITLE
Allow uploading 1GB file through nginx

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -2,6 +2,8 @@ server {
     listen 80;
     listen [::]:80;
 
+    client_max_body_size 1024M;
+
     location / {
         proxy_pass http://manage:9001;  # Streamlit
         proxy_http_version 1.1;


### PR DESCRIPTION
Nginx allows uploading file up to 1M by default. Set the max size to 1GB to align with the UI.