### PR TITLE
Add streaming to api

### DIFF
--- a/libs/gtypes.py
+++ b/libs/gtypes.py
@@ -2,6 +2,19 @@ from typing import Optional, Dict, List, Union, Literal, Any
 
 from pydantic import BaseModel
 
+class GenerateDataFileItem(BaseModel):
+    file_name: str
+    file_url: str
+    file_type: Optional[str]
+
+
+class GenerateDataRequest(BaseModel):
+    project_name: str
+    is_local_directory: bool
+    files: Optional[List[GenerateDataFileItem]]
+    directory: Optional[str]
+    
+
 
 class ChatCompletionMessageParam(BaseModel):
     content: str


### PR DESCRIPTION
add "data:" before stream output

## Summary by Sourcery

Implements streaming for the chat completions API by adding the "data:" prefix to the stream output and a [DONE] message at the end of the stream. Adds a utility function to guess file types based on file extensions.

Enhancements:
- Adds streaming support to the chat completions API.
- Adds a utility function to guess file types based on file extensions.